### PR TITLE
Support multiline blocks in REPL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.prosoft</groupId>
     <artifactId>local-lang</artifactId>
-    <version>v0.1.4</version>
+    <version>v0.1.5</version>
 
     <properties>
         <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
Wait for the closing brace before interpreting while typing blocks in REPL.

Ex:
```
>>> maanle party = sahi;
>>> agar (party) { // waits begins here
...   bolo "Aaj botlan khullan do. Daaru shaaru ghullan do";
... } varna {  // continues to wait coz a new '{'
...   bolo "Aunty police bula legi.";
... } // stops waiting and interprets at this point coz no brace in backstack
Aaj botlan khullan do. Daaru shaaru ghullan do
```